### PR TITLE
06 28 fixes

### DIFF
--- a/action/index.js
+++ b/action/index.js
@@ -49863,10 +49863,13 @@ void (async() => {
 
     // Use compare-versions to find the latest tag
     const latestTag = tags.reduce((latest, current) => {
-      const latestVer = latest || null
+      // No incumbent yet: adopt the first tag rather than comparing against
+      // null (which compareVersions.compare would throw on, leaving latest "").
+      if(!latest)
+        return current
 
       try {
-        return compare_versions__WEBPACK_IMPORTED_MODULE_3__.compare(current, latestVer, ">") ? current : latest
+        return compare_versions__WEBPACK_IMPORTED_MODULE_3__.compare(current, latest, ">") ? current : latest
       } catch {
       // If comparison fails, fallback to the current latest
         return latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "new-version-questionmark",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "new-version-questionmark",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "0BSD",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "new-version-questionmark",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Automatic version difference detection action for GitHub.",
   "type": "module",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -44,10 +44,13 @@ void (async() => {
 
     // Use compare-versions to find the latest tag
     const latestTag = tags.reduce((latest, current) => {
-      const latestVer = latest || null
+      // No incumbent yet: adopt the first tag rather than comparing against
+      // null (which compareVersions.compare would throw on, leaving latest "").
+      if(!latest)
+        return current
 
       try {
-        return compareVersions.compare(current, latestVer, ">") ? current : latest
+        return compareVersions.compare(current, latest, ">") ? current : latest
       } catch {
       // If comparison fails, fallback to the current latest
         return latest


### PR DESCRIPTION
- **fixes**
- **1.8.1**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch fixes a bug in the `tags.reduce()` call where the `""` seed value would be coerced to `null` via `latest || null`, causing `compareVersions.compare` to throw on the very first iteration and the catch block to return `""` — making `latestTag` always `""` and version detection permanently broken. The fix adds an early `if(!latest) return current` guard so the first real tag is adopted without any comparison.

- `src/index.js` / `action/index.js`: replaced the `latestVer = latest || null` pattern with an early-return guard that short-circuits to `current` when `latest` is falsy, then passes `latest` directly to `compare` for all subsequent iterations.
- `package.json` / `package-lock.json`: version bumped from 1.8.0 → 1.8.1 to reflect the patch release.

<h3>Confidence Score: 5/5</h3>

The change is a focused, correct bug fix with no behavioral regressions on happy paths and a direct improvement for the seed-value edge case.

The `if(!latest) return current` guard directly addresses the root cause — the `""` seed getting coerced to `null` and blowing up the compare call every single iteration. Both the source and the pre-built bundle are updated consistently, and the catch-block fallback still provides a safety net for genuinely invalid version strings.

No files require special attention; `action/index.js` (the bundled runtime) and `src/index.js` are in sync.

<sub>Reviews (1): Last reviewed commit: ["1.8.1"](https://github.com/gesslar/new-version-questionmark/commit/356114a92adb04f603c5e54d202b507773d27763) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40415046)</sub>

<!-- /greptile_comment -->